### PR TITLE
Fix int-conversion warning

### DIFF
--- a/unruu.c
+++ b/unruu.c
@@ -108,7 +108,7 @@ bool extract_ruu_files(FILE *ruu) {
     
     int c = 0;
     for(c = 0; c < strlen(RUU_FILES); c++)
-        if(strncmp(RUU_FILES+c, ",", 1) == 0)
+        if(strncmp(&RUU_FILES[c], ",", 1) == 0)
             count++;
     
     char files[] = RUU_FILES;


### PR DESCRIPTION
Fixing this error:

```
    unruu.c:111:20: warning: incompatible integer to pointer conversion passing
          'char' to parameter of type 'const char *'; take the address with &
          [-Wint-conversion]
            if(strncmp(RUU_FILES[c], ",", 1) == 0)
```
